### PR TITLE
Use subclassed errors instead of console.error()

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "release": "yarn test && node scripts/bump_version.js && npm publish"
   },
   "dependencies": {
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.10",
+    "make-error": "^1.3.5"
   },
   "devDependencies": {
     "@types/jest": "^23.3.2",

--- a/src/AccessControl.spec.ts
+++ b/src/AccessControl.spec.ts
@@ -1,6 +1,7 @@
 import AccessControl from './AccessControl';
 
 import rolesFixture from './__fixtures__/roles';
+import AccessControlError from './Errors/AccessControlError';
 
 type ConsoleLog = (message?: any, ...optionalParams: any[]) => void;
 type ConsoleError = ConsoleLog;
@@ -10,19 +11,9 @@ describe('Access Control', () => {
   let ACWithGrants: AccessControl;
   let ACWithoutGrants: AccessControl;
 
-  let mockConsoleLog: jest.Mock<ConsoleLog>;
-  let mockConsoleError: jest.Mock<ConsoleError>;
-
   beforeEach(() => {
     ACWithGrants = new AccessControl(rolesFixture);
     ACWithoutGrants = new AccessControl();
-
-    mockConsoleError = jest.spyOn(global.console, 'error').mockImplementation(() => {
-      return;
-    });
-    mockConsoleLog = jest.spyOn(global.console, 'log').mockImplementation(() => {
-      return;
-    });
   });
 
   it('`getRoles()` should return the data passed in the constructor', () => {
@@ -35,10 +26,8 @@ describe('Access Control', () => {
     expect(ACWithGrants.getRoles()).toEqual(rolesFixture);
   });
 
-  it('`getRoles()` should console.error if no grantsObj has been passed to AccessControl', () => {
-    ACWithoutGrants.getRoles();
-
-    expect(mockConsoleError).toHaveBeenCalled();
+  it('`getRoles()` should throw an error if no grants were passed to AccessControl', () => {
+    expect(() => { ACWithoutGrants.getRoles(); }).toThrow(AccessControlError);
   });
 
   it('get permission should return false', () => {
@@ -83,10 +72,9 @@ describe('Access Control', () => {
     });
   });
 
-  it('should `console.error` when trying to extend nonexistent role and role to keep the same', () => {
-    ACWithGrants.allow('Dev').toExtend('Text');
+  it('should throw an AccessControlError when trying to extend a nonexistent role', () => {
 
-    expect(mockConsoleError).toHaveBeenCalled();
+    expect(() => { ACWithGrants.allow('Dev').toExtend('Text'); }).toThrow(AccessControlError);
 
     // Role should not mutate if the error occurs
     const result = ACWithGrants.getRoles();
@@ -109,7 +97,6 @@ describe('Access Control', () => {
     ACWithGrants.allow('Test').toExtend('Dev');
 
     const result = ACWithGrants.getRoles();
-    expect(mockConsoleLog).toHaveBeenCalled();
     expect(result).toHaveProperty('Test');
     expect(result.Test).toEqual({
       GetUsers: {

--- a/src/AccessControl.ts
+++ b/src/AccessControl.ts
@@ -1,12 +1,13 @@
 import { cloneDeep, omit, isEmpty, map } from 'lodash';
 
-import { Roles, Permissions } from './types';
+import AccessControlError from './Errors/AccessControlError';
 import Step from './Steps/Step';
 import AllowStep from './Steps/AllowStep';
 import DenyStep from './Steps/DenyStep';
 import DoesAnyStep from './Steps/DoesAnyStep';
 import DoesStep from './Steps/DoesStep';
 import GrantStep from './Steps/GrantStep';
+import { Roles, Permissions } from './types';
 
 export default class AccessControl {
 
@@ -25,8 +26,7 @@ export default class AccessControl {
 
   getRoles(internal: Step | null = null): Roles {
     if (!this.hasRoles(this) && !internal) {
-      console.error(`AccessControl Error: AccessControl setup incorrectly. Please set grants before using it`);
-      return {};
+      throw new AccessControlError(`AccessControl setup incorrectly. Please set grants before using it`);
     }
 
     return cloneDeep(this.modifiedRoles);

--- a/src/Errors/AccessControlError.ts
+++ b/src/Errors/AccessControlError.ts
@@ -1,0 +1,11 @@
+import { BaseError } from 'make-error';
+
+export default class AccessControlError extends BaseError {
+  toObject = () => {
+    return {
+      message: this.message,
+      name: this.name,
+      stack: this.stack,
+    };
+  };
+}

--- a/src/Steps/AllowStep.ts
+++ b/src/Steps/AllowStep.ts
@@ -2,25 +2,25 @@ import { isEqual, each, includes } from 'lodash';
 
 import Step from './Step';
 import { Roles, Permissions, Grants } from '../types';
+import AccessControlError from '../Errors/AccessControlError';
 
 export default class AllowStep extends Step {
   toExtend(anotherRole: string):void {
     if (!this.parent.hasRoles(this)) {
-      console.error(`AccessControl Error: AccessControl setup incorrectly. Please set grants before using it`);
-      return;
+      throw new AccessControlError(`AccessControl setup incorrectly. Please set grants before using it`);
     }
 
     const roles: Roles = this.parent.getRoles(this);
 
     if (!roles[this.query.role!]) {
-      console.log(`AccessControl Warning: ${this.query.role} does not exist and will be created`);
+      // throw new AccessControlError(`AccessControl Error: AccessControl setup incorrectly. Please set grants before using it`);
+      // console.log(`AccessControl Warning: ${this.query.role} does not exist and will be created`);
       // return;
       roles[this.query.role!] = {};
     }
 
     if (!roles[anotherRole]) {
-      console.error(`AccessControl Error: Cannot extend ${anotherRole} role because it could not be found in roles`);
-      return;
+      throw new AccessControlError(`Cannot extend ${anotherRole} role because it could not be found in roles`);
     }
 
     const primaryRolePermissions:   Permissions = roles[this.query.role!];

--- a/src/Steps/DenyPermissionStep.ts
+++ b/src/Steps/DenyPermissionStep.ts
@@ -2,24 +2,22 @@ import { each, includes } from 'lodash';
 
 import Step from './Step';
 import { Roles } from '../types';
+import AccessControlError from '../Errors/AccessControlError';
 
 export default class DenyPermissionStep extends Step {
   for(...stages: string[]): void {
     if (!this.parent.hasRoles(this)) {
-      console.error(`AccessControl Error: AccessControl setup incorrectly. Please set grants before using it`);
-      return;
+      throw new AccessControlError(`AccessControl setup incorrectly. Please set grants before using it`)
     }
 
     const roles: Roles = this.parent.getRoles(this);
 
     if (!roles[this.query.role!]) {
-      console.error(`AccessControl Error: Cannot deny permissions for ${this.query.role} role because it could not be found in grants`);
-      return;
+      throw new AccessControlError(`Cannot deny permissions for ${this.query.role} role because it could not be found in grants`);
     }
 
     if (!roles[this.query.role!][this.query.permission!]) {
-      console.error(`AccessControl Error: Cannot deny ${this.query.permission} permission because it does not exist in ${this.query.role} role`);
-      return;
+      throw new AccessControlError(`Cannot deny ${this.query.permission} permission because it does not exist in ${this.query.role} role`);
     }
 
     each(stages, (stage: string) => {

--- a/src/Steps/PermissionCheckStep.ts
+++ b/src/Steps/PermissionCheckStep.ts
@@ -4,7 +4,7 @@ import Step from './Step';
 export default class PermissionCheckStep extends Step {
   hasPermission():boolean {
     if (!this.parent.hasRoles(this)) {
-      console.error(`AccessControl Error: AccessControl setup incorrectly. Please set grants before using it`);
+      // console.error(`AccessControl Error: AccessControl setup incorrectly. Please set grants before using it`);
       return false;
     }
 
@@ -13,12 +13,12 @@ export default class PermissionCheckStep extends Step {
     const query = this.query as GrantQuery;
 
     if (!roles[query.role]) {
-      console.error(`AccessControl Error: ${query.role} role could not be found in grants`);
+      // console.error(`AccessControl Error: ${query.role} role could not be found in grants`);
       return false;
     }
 
     if (!roles[query.role][query.permission]) {
-      console.error(`AccessControl Error: ${query.permission} permission could not be found for ${query.role} role`);
+      // console.error(`AccessControl Error: ${query.permission} permission could not be found for ${query.role} role`);
       return false;
     }
 


### PR DESCRIPTION
Now using errors subclassed from `make-error`, and updated tests. Also disabled any `console.log()` and `console.error()` calls.